### PR TITLE
Fix filedialog arguments

### DIFF
--- a/excel_creator.py
+++ b/excel_creator.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import messagebox, filedialog, ttk
-import os
 from datetime import datetime
 import csv
 
@@ -220,7 +219,7 @@ class ExcelCreator:
             file_path = filedialog.asksaveasfilename(
                 defaultextension=".xlsx",
                 filetypes=[("Excel files", "*.xlsx"), ("All files", "*.*")],
-                initialvalue=filename
+                initialfile=filename
             )
             
             if not file_path:
@@ -274,7 +273,7 @@ class ExcelCreator:
             file_path = filedialog.asksaveasfilename(
                 defaultextension=".csv",
                 filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
-                initialvalue=filename
+                initialfile=filename
             )
             
             if not file_path:


### PR DESCRIPTION
## Summary
- ensure asksaveasfilename uses `initialfile` for suggested filename
- drop unused `os` import

## Testing
- `python -m py_compile excel_creator.py`
- `python excel_creator.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68546c3526e0832ca11bbd82d2e13ab4